### PR TITLE
Rate limiting

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,10 @@ It integrates endpoints for:
 It also defines a basic root endpoint for a welcome message.
 """
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request, Response
+from slowapi.errors import RateLimitExceeded
+from middleware.rate_limiter import limiter, rate_limit_exceeded_handler
+
 from routes.ascor_routes import router as ascor_router
 from routes.company_routes import (
     router as company_router,
@@ -25,6 +28,12 @@ app = FastAPI(
     version="1.0",
     description="Provides company, MQ, and CP assessments via REST endpoints.",
 )
+
+# Add limiter to app state
+app.state.limiter = limiter
+
+# Add rate limit exceeded handler
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
 # -------------------------------------------------------------------------
 # Root Registration

--- a/main.py
+++ b/main.py
@@ -48,7 +48,8 @@ app.include_router(cp_router, prefix="/v1")
 # Root Endpoint
 # -------------------------------------------------------------------------
 @app.get("/")
-def home():
+@limiter.limit("100/minute")
+async def home(request: Request):
     """
     Root endpoint that returns a welcome message.
     """

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -1,4 +1,8 @@
-from fastapi import Request, HTTPException, Response, Request
+"""
+This module provides the rate limiter for the FastAPI. It also creates the limit exceeded error handler.
+"""
+
+from fastapi import Request, HTTPException, Response
 from fastapi.responses import JSONResponse
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -6,7 +10,9 @@ from slowapi.middleware import SlowAPIMiddleware
 from slowapi.errors import RateLimitExceeded
 
 # Initialize limiter
-limiter = Limiter(key_func=get_remote_address, default_limits=["1/minute"])
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["100/minute"])
 
 # Create error handler for rate limit exceeded
 async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded):

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -1,0 +1,19 @@
+from fastapi import Request, HTTPException, Response, Request
+from fastapi.responses import JSONResponse
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.errors import RateLimitExceeded
+
+# Initialize limiter
+limiter = Limiter(key_func=get_remote_address, default_limits=["1/minute"])
+
+# Create error handler for rate limit exceeded
+async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded):
+    return JSONResponse(
+        status_code=429,
+        content={
+            "detail": "Rate limit exceeded. Too many requests.",
+            "retry_after": "Try again after 1 minute, when your requests will reset.",
+        },
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ typing_extensions==4.12.2
 tzdata==2025.1
 urllib3==2.3.0
 uvicorn==0.34.0
+slowapi==0.1.9

--- a/routes/ascor_routes.py
+++ b/routes/ascor_routes.py
@@ -1,11 +1,11 @@
 import os
 import pandas as pd
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, FastAPI, Request
 from schemas import CountryDataResponse
 from services import CountryDataProcessor
+from middleware.rate_limiter import limiter
 
-from fastapi import FastAPI, HTTPException
 
 # TODO: Handle the data loading in a better way
 filepath = "./data/TPI ASCOR data - 13012025/ASCOR_assessments_results.xlsx"
@@ -17,7 +17,8 @@ df_assessments = pd.read_excel(filepath, engine='openpyxl')
 router = APIRouter(prefix="/ascor", tags=["ASCOR Endpoints"])
 
 @router.get("/country-data/{country}/{assessment_year}", response_model=CountryDataResponse)
-async def get_country_data(country: str, assessment_year: int) -> CountryDataResponse:
+@limiter.limit("100/minute")
+async def get_country_data(request: Request, country: str, assessment_year: int) -> CountryDataResponse:
     try:
         processor = CountryDataProcessor(df_assessments, country, assessment_year)
         return processor.process_country_data()

--- a/routes/company_routes.py
+++ b/routes/company_routes.py
@@ -62,7 +62,7 @@ router = APIRouter(prefix="/company", tags=["Company Endpoints"])
 # --------------------------------------------------------------------------
 @router.get("/companies", response_model=CompanyListResponse)
 @limiter.limit("100/minute")
-def get_all_companies(
+async def get_all_companies(
     request: Request,
     page: int = Query(1, ge=1, description="Page number"),
     per_page: int = Query(10, ge=1, le=100, description="Results per page"),
@@ -112,7 +112,7 @@ def get_all_companies(
 # ------------------------------------------------------------------------------
 @router.get("/company/{company_id}", response_model=CompanyDetail)
 @limiter.limit("100/minute")
-def get_company_details(request: Request, company_id: str):
+async def get_company_details(request: Request, company_id: str):
     """
     Retrieve the latest MQ & CP scores for a specific company.
 
@@ -158,7 +158,7 @@ def get_company_details(request: Request, company_id: str):
     "/company/{company_id}/history", response_model=CompanyHistoryResponse
 )
 @limiter.limit("100/minute")
-def get_company_history(request: Request, company_id: str):
+async def get_company_history(request: Request, company_id: str):
     """
     Retrieve a company's historical MQ & CP scores.
 
@@ -246,7 +246,7 @@ def get_company_history(request: Request, company_id: str):
     ],
 )
 @limiter.limit("100/minute")
-def compare_company_performance(request: Request, company_id: str):
+async def compare_company_performance(request: Request, company_id: str):
     """
     Compare a company's latest performance against the previous year.
 

--- a/routes/company_routes.py
+++ b/routes/company_routes.py
@@ -9,11 +9,12 @@ and comparing performance between assessment cycles.
 # Imports
 # -------------------------------------------------------------------------
 import re
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 import pandas as pd
 from pathlib import Path as FilePath
 from datetime import datetime
 from typing import Union
+from middleware.rate_limiter import limiter
 from schemas import (
     CompanyBase,
     CompanyDetail,
@@ -60,7 +61,9 @@ router = APIRouter(prefix="/company", tags=["Company Endpoints"])
 # Endpoint: GET /companies - List All Companies with Pagination
 # --------------------------------------------------------------------------
 @router.get("/companies", response_model=CompanyListResponse)
+@limiter.limit("100/minute")
 def get_all_companies(
+    request: Request,
     page: int = Query(1, ge=1, description="Page number"),
     per_page: int = Query(10, ge=1, le=100, description="Results per page"),
 ):
@@ -108,7 +111,8 @@ def get_all_companies(
 # Endpoint: GET /company/{company_id} - Retrieve Company Details
 # ------------------------------------------------------------------------------
 @router.get("/company/{company_id}", response_model=CompanyDetail)
-def get_company_details(company_id: str):
+@limiter.limit("100/minute")
+def get_company_details(request: Request, company_id: str):
     """
     Retrieve the latest MQ & CP scores for a specific company.
 
@@ -153,7 +157,8 @@ def get_company_details(company_id: str):
 @router.get(
     "/company/{company_id}/history", response_model=CompanyHistoryResponse
 )
-def get_company_history(company_id: str):
+@limiter.limit("100/minute")
+def get_company_history(request: Request, company_id: str):
     """
     Retrieve a company's historical MQ & CP scores.
 
@@ -240,7 +245,8 @@ def get_company_history(company_id: str):
         PerformanceComparisonInsufficientDataResponse,
     ],
 )
-def compare_company_performance(company_id: str):
+@limiter.limit("100/minute")
+def compare_company_performance(request: Request, company_id: str):
     """
     Compare a company's latest performance against the previous year.
 

--- a/routes/cp_routes.py
+++ b/routes/cp_routes.py
@@ -52,8 +52,8 @@ cp_router = APIRouter(prefix="/cp", tags=["CP Endpoints"])
 # Endpoint: GET /latest - Latest CP Assessments with Pagination
 # ------------------------------------------------------------------------------
 @cp_router.get("/latest", response_model=List[CPAssessmentDetail])
-@limiter.limit("100/minute")
-def get_latest_cp_assessments(
+@limiter.limit("2/minute")
+async def get_latest_cp_assessments(
     request: Request, 
     page: int = Query(1, ge=1, description="Page number (1-based index)"),
     page_size: int = Query(
@@ -103,7 +103,7 @@ def get_latest_cp_assessments(
     "/company/{company_id}", response_model=List[CPAssessmentDetail]
 )
 @limiter.limit("100/minute")
-def get_company_cp_history(request: Request, company_id: str):
+async def get_company_cp_history(request: Request, company_id: str):
     """
     Retrieve all CP assessments for a specific company across different assessment cycles.
     """
@@ -141,7 +141,7 @@ def get_company_cp_history(request: Request, company_id: str):
     "/company/{company_id}/alignment", response_model=Dict[str, str]
 )
 @limiter.limit("100/minute")
-def get_company_cp_alignment(request: Request, company_id: str):
+async def get_company_cp_alignment(request: Request, company_id: str):
     """
     Retrieves a company's carbon performance alignment status across target years
     """
@@ -176,7 +176,7 @@ def get_company_cp_alignment(request: Request, company_id: str):
     ],
 )
 @limiter.limit("100/minute")
-def compare_company_cp(request: Request, company_id: str):
+async def compare_company_cp(request: Request, company_id: str):
     """
     Compare the most recent CP assessment to the previous one for a company.
     """

--- a/routes/mq_routes.py
+++ b/routes/mq_routes.py
@@ -61,8 +61,8 @@ mq_router = APIRouter(prefix="/mq", tags=["MQ Endpoints"])
 # Endpoint: GET /latest - Latest MQ Assessments with Pagination
 # ------------------------------------------------------------------------------
 @mq_router.get("/latest", response_model=PaginatedMQResponse)
-@limiter.limit("2/minute")
-def get_latest_mq_assessments(
+@limiter.limit("100/minute")
+async def get_latest_mq_assessments(
     request: Request, 
     page: int = Query(1, ge=1, description="Page number (1-based index)"),
     page_size: int = Query(
@@ -119,7 +119,7 @@ def get_latest_mq_assessments(
     "/methodology/{methodology_id}", response_model=PaginatedMQResponse
 )
 @limiter.limit("100/minute")
-def get_mq_by_methodology(
+async def get_mq_by_methodology(
     request: Request, 
     methodology_id: int = Path(
         ..., ge=1, le=len(mq_files), description="Methodology cycle ID"
@@ -171,7 +171,7 @@ def get_mq_by_methodology(
     "/trends/sector/{sector_id}", response_model=PaginatedMQResponse
 )
 @limiter.limit("100/minute")
-def get_mq_trends_sector(
+async def get_mq_trends_sector(
     request: Request, 
     sector_id: str,
     page: int = Query(1, ge=1, description="Page number"),


### PR DESCRIPTION
Closes #26

## Major changes

- Created a limiter using slowAPI that limits endpoints to 100 requests per minute per IP address
- Created error response that will return a 429 Too Many Requests error if limit exceeded
- Changed requirements.txt as necessary

## How to validate

To confirm that this PR does what it is supposed to do and doesn't break anything:

Easier method:

1. Choose an endpoint to test with (eg. `/country-data/{country}/{assessment_year}`)
2. Change the requests per minute in the `@limiter.limit("100/minute")` line in the chosen function to `@limiter.limit("2/minute")` 
4. Run the API using uvicorn as normal
5. Request the endpoint 3 times
6. You will get an 429 error
7. Change the limits on the endpoint you want to test back to `@limiter.limit("100/minute")`

Less efficient method:

1. Run the API using uvicorn as normal
2. Request any endpoint >100 times
3. You will get an 429 error
